### PR TITLE
Fixes kotlin nullability issue #21

### DIFF
--- a/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
+++ b/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
@@ -317,7 +317,7 @@ class FlutterKeychainPlugin : MethodCallHandler {
                 else -> result.notImplemented()
             }
         } catch (e: Exception) {
-            Log.e("flutter_keychain", e.message)
+            Log.e("flutter_keychain", e.message ?: e.toString())
             result.error("flutter_keychain", e.message, e)
         }
     }


### PR DESCRIPTION
This should fix issue #21 by providing a fallback to `e.toString()` when `e.message` is null