### PR TITLE
feat(iOS): configurable kSecAttrAccessible with legacy migration (3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,12 @@
 **New features**
 * Dart: `FlutterKeychain.configure` accepts optional `accessible` via the
   `FlutterKeychainAccessible` enum.
-* iOS: `accessible` sets `kSecAttrAccessible` on stored Keychain items.
-* Android: `configure` remains a no-op for `accessible` (no 1:1 Keychain equivalent).
+* Dart: `accessibilityMigration` (`none` or `automatic`) controls lazy migration of
+  existing iOS Keychain items to the configured `accessible` value.
+* iOS: `accessible` applies on `SecItemAdd` and optional migration updates; reads,
+  deletes, and existence checks use an identity query without `kSecAttrAccessible` so
+  legacy items remain readable.
+* Android: `configure` remains a no-op for iOS-only settings (no 1:1 Keychain equivalent).
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.1.0
+
+**New features**
+* Dart: `FlutterKeychain.configure` accepts optional `accessible` via the
+  `FlutterKeychainAccessible` enum.
+* iOS: `accessible` sets `kSecAttrAccessible` on stored Keychain items.
+* Android: `configure` remains a no-op for `accessible` (no 1:1 Keychain equivalent).
+
 ## 3.0.1
 
 * Update public API documentation comments for pub.dev scoring.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,22 @@ await FlutterKeychain.clear();
 
 ```
 
+### iOS configuration (optional)
+
+Call `configure` before the first read/write when you need non-default Keychain behaviour.
+`accessGroup` and `label` are iOS-only. `accessible` maps to `kSecAttrAccessible` and is also iOS-only.
+
+```dart
+await FlutterKeychain.configure(
+  accessGroup: 'group.com.example.shared',
+  label: 'My App Credentials',
+  accessible: FlutterKeychainAccessible.afterFirstUnlock,
+);
+```
+
+On Android, `configure` is a no-op. Android does not expose a per-item equivalent of
+`kSecAttrAccessible`; stored values use the plugin's existing Keystore-backed encryption.
+
 ### Configure Android version
 In `[project]/android/app/build.gradle` set `minSdkVersion` to >= 18.
 ```

--- a/README.md
+++ b/README.md
@@ -33,15 +33,33 @@ await FlutterKeychain.clear();
 ### iOS configuration (optional)
 
 Call `configure` before the first read/write when you need non-default Keychain behaviour.
-`accessGroup` and `label` are iOS-only. `accessible` maps to `kSecAttrAccessible` and is also iOS-only.
+`accessGroup`, `label`, `accessible`, and `accessibilityMigration` are iOS-only.
 
 ```dart
 await FlutterKeychain.configure(
   accessGroup: 'group.com.example.shared',
   label: 'My App Credentials',
   accessible: FlutterKeychainAccessible.afterFirstUnlock,
+  // Default: do not change existing items (reads stay compatible).
+  accessibilityMigration: FlutterKeychainAccessibilityMigration.none,
 );
 ```
+
+`accessible` is applied when **adding** new Keychain items. Reads and deletes do not filter by
+`accessible`, so data written before you changed the setting remains readable.
+
+To upgrade older items (for example from the system default `whenUnlocked` to
+`afterFirstUnlock`), opt in to lazy migration:
+
+```dart
+await FlutterKeychain.configure(
+  accessible: FlutterKeychainAccessible.afterFirstUnlock,
+  accessibilityMigration: FlutterKeychainAccessibilityMigration.automatic,
+);
+```
+
+With `automatic`, a successful `get` or `put` update attempts to migrate that item's
+`kSecAttrAccessible`. Migration failures are logged and do not affect the returned value.
 
 On Android, `configure` is a no-op. Android does not expose a per-item equivalent of
 `kSecAttrAccessible`; stored values use the plugin's existing Keystore-backed encryption.

--- a/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
+++ b/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
@@ -387,7 +387,7 @@ class FlutterKeychainPlugin : FlutterPlugin, MethodCallHandler {
                         result.success(null)
                     }
                     "configure" -> {
-                        // accessGroup, label, and accessible are iOS-only; no-op on Android.
+                        // accessGroup, label, accessible, accessibilityMigration: iOS-only.
                         result.success(null)
                     }
                     else -> result.notImplemented()

--- a/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
+++ b/android/src/main/kotlin/be/appmire/flutterkeychain/FlutterKeychainPlugin.kt
@@ -387,7 +387,7 @@ class FlutterKeychainPlugin : FlutterPlugin, MethodCallHandler {
                         result.success(null)
                     }
                     "configure" -> {
-                        // Access groups and labels are iOS-only; no-op on Android.
+                        // accessGroup, label, and accessible are iOS-only; no-op on Android.
                         result.success(null)
                     }
                     else -> result.notImplemented()

--- a/example/ios/RunnerTests/FlutterKeychainPluginTests.m
+++ b/example/ios/RunnerTests/FlutterKeychainPluginTests.m
@@ -349,6 +349,84 @@
     XCTAssertEqualObjects(error.code, @"INVALID_ACCESSIBLE");
 }
 
+- (void)testConfigure_withUnknownMigration_returnsFlutterError {
+    __block id returnValue = nil;
+    FlutterMethodCall *call =
+        [FlutterMethodCall methodCallWithMethodName:@"configure"
+                                           arguments:@{@"accessibilityMigration": @"invalid"}];
+    [self.plugin handleMethodCall:call result:^(id result) {
+        returnValue = result;
+    }];
+    XCTAssertTrue([returnValue isKindOfClass:[FlutterError class]]);
+    FlutterError *error = (FlutterError *)returnValue;
+    XCTAssertEqualObjects(error.code, @"INVALID_ACCESSIBILITY_MIGRATION");
+}
+
+- (CFStringRef)accessibleAttributeForKey:(NSString *)key {
+    NSMutableDictionary *search = [NSMutableDictionary dictionary];
+    search[(__bridge id)kSecClass]       = (__bridge id)kSecClassGenericPassword;
+    search[(__bridge id)kSecAttrService] = @"flutter_keychain";
+    search[(__bridge id)kSecAttrAccount] = key;
+    search[(__bridge id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
+    search[(__bridge id)kSecMatchLimit]  = (__bridge id)kSecMatchLimitOne;
+
+    CFDictionaryRef attrs = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)search,
+                                          (CFTypeRef *)&attrs);
+    if (status == noErr && attrs != NULL) {
+        NSDictionary *dict = (__bridge_transfer NSDictionary *)attrs;
+        return (__bridge CFStringRef)dict[(__bridge id)kSecAttrAccessible];
+    }
+    return NULL;
+}
+
+- (void)testLegacyItem_readableAfterAccessibleReconfigure {
+    // Legacy item: default configure (system whenUnlocked on add).
+    [self invokeMethod:@"put" arguments:@{@"key": @"legacy", @"value": @"old"}];
+
+    // Reconfigure to afterFirstUnlock without migration — must still read.
+    [self invokeMethod:@"configure"
+             arguments:@{@"accessible": @"afterFirstUnlock",
+                         @"accessibilityMigration": @"none"}];
+    XCTAssertEqualObjects(
+        [self invokeMethod:@"get" arguments:@{@"key": @"legacy"}], @"old");
+
+    [self invokeMethod:@"configure" arguments:@{}];
+}
+
+- (void)testLegacyItem_automaticMigrationUpdatesAccessible {
+    [self invokeMethod:@"put" arguments:@{@"key": @"migrate", @"value": @"data"}];
+
+    CFStringRef before = [self accessibleAttributeForKey:@"migrate"];
+    XCTAssertEqual(before, kSecAttrAccessibleWhenUnlocked);
+
+    [self invokeMethod:@"configure"
+             arguments:@{@"accessible": @"afterFirstUnlock",
+                         @"accessibilityMigration": @"automatic"}];
+    XCTAssertEqualObjects(
+        [self invokeMethod:@"get" arguments:@{@"key": @"migrate"}], @"data");
+
+    CFStringRef after = [self accessibleAttributeForKey:@"migrate"];
+    XCTAssertEqual(after, kSecAttrAccessibleAfterFirstUnlock);
+
+    [self invokeMethod:@"configure" arguments:@{}];
+}
+
+- (void)testLegacyItem_noneMigrationLeavesAccessibleUnchanged {
+    [self invokeMethod:@"put" arguments:@{@"key": @"nomigrate", @"value": @"stay"}];
+
+    [self invokeMethod:@"configure"
+             arguments:@{@"accessible": @"afterFirstUnlock",
+                         @"accessibilityMigration": @"none"}];
+    XCTAssertEqualObjects(
+        [self invokeMethod:@"get" arguments:@{@"key": @"nomigrate"}], @"stay");
+
+    CFStringRef accessible = [self accessibleAttributeForKey:@"nomigrate"];
+    XCTAssertEqual(accessible, kSecAttrAccessibleWhenUnlocked);
+
+    [self invokeMethod:@"configure" arguments:@{}];
+}
+
 // ---------------------------------------------------------------------------
 // Method channel – unimplemented method
 // ---------------------------------------------------------------------------

--- a/example/ios/RunnerTests/FlutterKeychainPluginTests.m
+++ b/example/ios/RunnerTests/FlutterKeychainPluginTests.m
@@ -328,6 +328,27 @@
     [self invokeMethod:@"configure" arguments:@{}];
 }
 
+- (void)testConfigure_withAccessible_itemsStillRetrievable {
+    [self invokeMethod:@"configure"
+             arguments:@{@"accessible": @"afterFirstUnlock"}];
+    [self invokeMethod:@"put" arguments:@{@"key": @"ak", @"value": @"av"}];
+    XCTAssertEqualObjects([self invokeMethod:@"get" arguments:@{@"key": @"ak"}], @"av");
+    [self invokeMethod:@"configure" arguments:@{}];
+}
+
+- (void)testConfigure_withUnknownAccessible_returnsFlutterError {
+    __block id returnValue = nil;
+    FlutterMethodCall *call =
+        [FlutterMethodCall methodCallWithMethodName:@"configure"
+                                           arguments:@{@"accessible": @"invalid"}];
+    [self.plugin handleMethodCall:call result:^(id result) {
+        returnValue = result;
+    }];
+    XCTAssertTrue([returnValue isKindOfClass:[FlutterError class]]);
+    FlutterError *error = (FlutterError *)returnValue;
+    XCTAssertEqualObjects(error.code, @"INVALID_ACCESSIBLE");
+}
+
 // ---------------------------------------------------------------------------
 // Method channel – unimplemented method
 // ---------------------------------------------------------------------------

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,32 +5,32 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
-      url: "https://pub.dev"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.13.1"
+    version: "2.12.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       sha256: "8aab1771e1243a5063b8b0ff68042d67334e3feab9e95b9490f9a6ebf73b42ea"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.2"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
-      url: "https://pub.dev"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.1"
+    version: "1.4.0"
   clock:
     dependency: transitive
     description:
       name: clock
       sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.2"
   collection:
@@ -38,25 +38,25 @@ packages:
     description:
       name: collection
       sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
-      url: "https://pub.dev"
+      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.0.9"
+    version: "1.0.8"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
-      url: "https://pub.dev"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +68,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.0"
+    version: "3.1.0"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -78,56 +78,56 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
-      url: "https://pub.dev"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
-      url: "https://pub.dev"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
-      url: "https://pub.dev"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
-      url: "https://pub.dev"
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
-      url: "https://pub.dev"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.13.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
-      url: "https://pub.dev"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   path:
     dependency: transitive
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.9.1"
   sky_engine:
@@ -139,16 +139,16 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
-      url: "https://pub.dev"
+      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.10.2"
+    version: "1.10.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.12.1"
   stream_channel:
@@ -156,7 +156,7 @@ packages:
     description:
       name: stream_channel
       sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.1.4"
   string_scanner:
@@ -164,7 +164,7 @@ packages:
     description:
       name: string_scanner
       sha256: "921cd31725b72fe181906c6a94d987c78e3b98c2e205b397ea399d4054872b43"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.4.1"
   term_glyph:
@@ -172,33 +172,33 @@ packages:
     description:
       name: term_glyph
       sha256: "7f554798625ea768a7518313e58f83891c7f5024f88e46e7182a4558850a4b8e"
-      url: "https://pub.dev"
+      url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.2.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
-      url: "https://pub.dev"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.4"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
-      url: "https://pub.dev"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
-      url: "https://pub.dev"
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "15.0.2"
+    version: "14.3.1"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.7.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/ios/Classes/FlutterKeychainPlugin.h
+++ b/ios/Classes/FlutterKeychainPlugin.h
@@ -14,11 +14,16 @@ NS_ASSUME_NONNULL_BEGIN
  * @param label        kSecAttrLabel string shown in iOS Passwords
  *                     (Settings > Passwords). Pass nil to omit the label.
  * @param accessible   kSecAttrAccessible value as a stable string token
- *                     (e.g. "afterFirstUnlock"). Pass nil for system default.
+ *                     (e.g. "afterFirstUnlock"). Pass nil for system default
+ *                     on newly added items only.
+ * @param accessibilityMigration  "none" or "automatic". When "automatic",
+ *                     successful reads/updates attempt to migrate existing
+ *                     items to @p accessible.
  */
 - (void)configureWithAccessGroup:(nullable NSString *)accessGroup
                            label:(nullable NSString *)label
-                      accessible:(nullable NSString *)accessible;
+                      accessible:(nullable NSString *)accessible
+         accessibilityMigration:(nullable NSString *)accessibilityMigration;
 
 @end
 

--- a/ios/Classes/FlutterKeychainPlugin.h
+++ b/ios/Classes/FlutterKeychainPlugin.h
@@ -13,9 +13,12 @@ NS_ASSUME_NONNULL_BEGIN
  *                     Pass nil to use the default (app-specific) access group.
  * @param label        kSecAttrLabel string shown in iOS Passwords
  *                     (Settings > Passwords). Pass nil to omit the label.
+ * @param accessible   kSecAttrAccessible value as a stable string token
+ *                     (e.g. "afterFirstUnlock"). Pass nil for system default.
  */
 - (void)configureWithAccessGroup:(nullable NSString *)accessGroup
-                           label:(nullable NSString *)label;
+                           label:(nullable NSString *)label
+                      accessible:(nullable NSString *)accessible;
 
 @end
 

--- a/ios/Classes/FlutterKeychainPlugin.m
+++ b/ios/Classes/FlutterKeychainPlugin.m
@@ -31,8 +31,13 @@ static NSString *const CHANNEL_NAME     = @"plugin.appmire.be/flutter_keychain";
 // ---------------------------------------------------------------------------
 
 @interface FlutterKeychainPlugin ()
-/// Base query dictionary rebuilt by -configureWithAccessGroup:label:accessible:.
-@property (nonatomic, copy) NSDictionary *baseQuery;
+/// Identity query: class, service, optional access group/label. Never includes
+/// kSecAttrAccessible so reads/deletes remain compatible with legacy items.
+@property (nonatomic, copy) NSDictionary *identityQuery;
+/// Configured accessible token from Dart, or nil for system default on add.
+@property (nonatomic, copy, nullable) NSString *configuredAccessible;
+/// When YES, lazily migrate existing items after successful get/put update.
+@property (nonatomic, assign) BOOL automaticAccessibilityMigration;
 @end
 
 // Maps Dart [FlutterKeychainAccessible] values to kSecAttrAccessible constants.
@@ -55,13 +60,37 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
     return NULL;
 }
 
+static NSString *AccessibleTokenForConstant(CFStringRef accessible) {
+    if (accessible == NULL) {
+        return @"unknown";
+    }
+    if (CFEqual(accessible, kSecAttrAccessibleWhenUnlocked)) {
+        return @"whenUnlocked";
+    }
+    if (CFEqual(accessible, kSecAttrAccessibleAfterFirstUnlock)) {
+        return @"afterFirstUnlock";
+    }
+    if (CFEqual(accessible, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)) {
+        return @"whenPasscodeSetThisDeviceOnly";
+    }
+    if (CFEqual(accessible, kSecAttrAccessibleWhenUnlockedThisDeviceOnly)) {
+        return @"whenUnlockedThisDeviceOnly";
+    }
+    if (CFEqual(accessible, kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)) {
+        return @"afterFirstUnlockThisDeviceOnly";
+    }
+    return @"unknown";
+}
+
 @implementation FlutterKeychainPlugin
 
 - (instancetype)init {
     self = [super init];
     if (self) {
-        // Default: app-specific access group, no label, system accessible default.
-        [self configureWithAccessGroup:nil label:nil accessible:nil];
+        [self configureWithAccessGroup:nil
+                                 label:nil
+                            accessible:nil
+               accessibilityMigration:@"none"];
     }
     return self;
 }
@@ -80,7 +109,8 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
 
 - (void)configureWithAccessGroup:(nullable NSString *)accessGroup
                            label:(nullable NSString *)label
-                      accessible:(nullable NSString *)accessible {
+                      accessible:(nullable NSString *)accessible
+         accessibilityMigration:(nullable NSString *)accessibilityMigration {
     NSMutableDictionary *q = [NSMutableDictionary dictionary];
     q[(__bridge id)kSecClass]       = (__bridge id)kSecClassGenericPassword;
     q[(__bridge id)kSecAttrService] = KEYCHAIN_SERVICE;
@@ -90,13 +120,83 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
     if (label.length > 0) {
         q[(__bridge id)kSecAttrLabel] = label;
     }
-    if (accessible.length > 0) {
-        CFStringRef accessibleConstant = AccessibleConstantForString(accessible);
-        if (accessibleConstant != NULL) {
-            q[(__bridge id)kSecAttrAccessible] = (__bridge id)accessibleConstant;
-        }
+    self.identityQuery = [q copy];
+    self.configuredAccessible = accessible.length > 0 ? [accessible copy] : nil;
+    self.automaticAccessibilityMigration =
+        [@"automatic" isEqualToString:accessibilityMigration];
+}
+
+- (NSMutableDictionary *)identityQueryForKey:(NSString *)key {
+    NSMutableDictionary *query = [self.identityQuery mutableCopy];
+    query[(__bridge id)kSecAttrAccount] = key;
+    return query;
+}
+
+- (BOOL)shouldAttemptAccessibilityMigration {
+    return self.automaticAccessibilityMigration &&
+           self.configuredAccessible.length > 0 &&
+           AccessibleConstantForString(self.configuredAccessible) != NULL;
+}
+
+- (nullable CFStringRef)currentAccessibleConstantForKey:(NSString *)key {
+    NSMutableDictionary *search = [self identityQueryForKey:key];
+    search[(__bridge id)kSecReturnAttributes] = (__bridge id)kCFBooleanTrue;
+    search[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
+
+    CFDictionaryRef attrs = NULL;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)search,
+                                          (CFTypeRef *)&attrs);
+    if (status != noErr || attrs == NULL) {
+        return NULL;
     }
-    self.baseQuery = [q copy];
+    NSDictionary *dict = (__bridge_transfer NSDictionary *)attrs;
+    return (__bridge CFStringRef)dict[(__bridge id)kSecAttrAccessible];
+}
+
+- (void)migrateAccessibilityForKey:(NSString *)key
+                          withData:(NSData *)data
+                            source:(NSString *)source {
+    if (![self shouldAttemptAccessibilityMigration]) {
+        return;
+    }
+    CFStringRef accessibleConstant =
+        AccessibleConstantForString(self.configuredAccessible);
+    CFStringRef currentAccessible = [self currentAccessibleConstantForKey:key];
+    if (currentAccessible != NULL &&
+        CFEqual(currentAccessible, accessibleConstant)) {
+        NSLog(@"[flutter_keychain] accessibility migration skipped for key "
+              @"'%@' (already %@, trigger: %@)",
+              key, self.configuredAccessible, source);
+        return;
+    }
+
+    NSString *fromToken = currentAccessible != NULL
+        ? AccessibleTokenForConstant(currentAccessible)
+        : @"legacy/default";
+    NSLog(@"[flutter_keychain] accessibility migration started for key '%@' "
+          @"from %@ to %@ (trigger: %@)",
+          key, fromToken, self.configuredAccessible, source);
+
+    NSMutableDictionary *query = [self identityQueryForKey:key];
+    NSDictionary *update = @{
+        (__bridge id)kSecAttrAccessible: (__bridge id)accessibleConstant,
+        (__bridge id)kSecValueData: data,
+    };
+    OSStatus status = SecItemUpdate((__bridge CFDictionaryRef)query,
+                                    (__bridge CFDictionaryRef)update);
+    if (status == noErr) {
+        NSLog(@"[flutter_keychain] accessibility migration succeeded for key "
+              @"'%@' (trigger: %@)",
+              key, source);
+    } else {
+        NSLog(@"[flutter_keychain] accessibility migration failed for key "
+              @"'%@' status = %d (trigger: %@)",
+              key, (int)status, source);
+    }
+}
+
+- (void)migrateAccessibilityForKey:(NSString *)key withData:(NSData *)data {
+    [self migrateAccessibilityForKey:key withData:data source:@"get"];
 }
 
 // ---------------------------------------------------------------------------
@@ -106,13 +206,15 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
     if ([@"configure" isEqualToString:call.method]) {
         NSDictionary *args = call.arguments;
-        // Dart sends NSNull when an optional String? is nil.
         NSString *accessGroup = [args[@"accessGroup"] isKindOfClass:[NSString class]]
             ? args[@"accessGroup"] : nil;
         NSString *label = [args[@"label"] isKindOfClass:[NSString class]]
             ? args[@"label"] : nil;
         NSString *accessible = [args[@"accessible"] isKindOfClass:[NSString class]]
             ? args[@"accessible"] : nil;
+        NSString *migration =
+            [args[@"accessibilityMigration"] isKindOfClass:[NSString class]]
+            ? args[@"accessibilityMigration"] : @"none";
         if (accessible.length > 0 &&
             AccessibleConstantForString(accessible) == NULL) {
             result([FlutterError errorWithCode:@"INVALID_ACCESSIBLE"
@@ -120,9 +222,17 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
                                        details:accessible]);
             return;
         }
+        if (![@"none" isEqualToString:migration] &&
+            ![@"automatic" isEqualToString:migration]) {
+            result([FlutterError errorWithCode:@"INVALID_ACCESSIBILITY_MIGRATION"
+                                       message:@"Unknown accessibilityMigration value"
+                                       details:migration]);
+            return;
+        }
         [self configureWithAccessGroup:accessGroup
                                  label:label
-                            accessible:accessible];
+                            accessible:accessible
+               accessibilityMigration:migration];
         result(nil);
     } else if ([@"get" isEqualToString:call.method]) {
         result([self get:call.key]);
@@ -145,27 +255,64 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
 // ---------------------------------------------------------------------------
 
 - (void)put:(NSString *)value forKey:(NSString *)key {
-    NSMutableDictionary *search = [self.baseQuery mutableCopy];
-    search[(__bridge id)kSecAttrAccount] = key;
-    search[(__bridge id)kSecMatchLimit]  = (__bridge id)kSecMatchLimitOne;
+    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
+    NSMutableDictionary *search = [self identityQueryForKey:key];
+    search[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitOne;
 
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)search, NULL);
     if (status == noErr) {
-        // Item exists — update its data.
-        search[(__bridge id)kSecMatchLimit] = nil;
-        NSDictionary *update = @{
-            (__bridge id)kSecValueData: [value dataUsingEncoding:NSUTF8StringEncoding]
-        };
-        status = SecItemUpdate((__bridge CFDictionaryRef)search,
+        NSMutableDictionary *updateQuery = [self identityQueryForKey:key];
+        NSMutableDictionary *update = [NSMutableDictionary dictionary];
+        update[(__bridge id)kSecValueData] = data;
+        if ([self shouldAttemptAccessibilityMigration]) {
+            CFStringRef accessibleConstant =
+                AccessibleConstantForString(self.configuredAccessible);
+            CFStringRef currentAccessible =
+                [self currentAccessibleConstantForKey:key];
+            if (currentAccessible != NULL &&
+                CFEqual(currentAccessible, accessibleConstant)) {
+                NSLog(@"[flutter_keychain] accessibility migration skipped for "
+                      @"key '%@' (already %@, trigger: put)",
+                      key, self.configuredAccessible);
+            } else {
+                NSString *fromToken = currentAccessible != NULL
+                    ? AccessibleTokenForConstant(currentAccessible)
+                    : @"legacy/default";
+                NSLog(@"[flutter_keychain] accessibility migration started for "
+                      @"key '%@' from %@ to %@ (trigger: put)",
+                      key, fromToken, self.configuredAccessible);
+                update[(__bridge id)kSecAttrAccessible] =
+                    (__bridge id)accessibleConstant;
+            }
+        }
+        status = SecItemUpdate((__bridge CFDictionaryRef)updateQuery,
                                (__bridge CFDictionaryRef)update);
         if (status != noErr) {
             NSLog(@"[flutter_keychain] SecItemUpdate status = %d", (int)status);
+            if ([self shouldAttemptAccessibilityMigration] &&
+                update[(__bridge id)kSecAttrAccessible] != nil) {
+                NSLog(@"[flutter_keychain] accessibility migration failed for "
+                      @"key '%@' status = %d (trigger: put)",
+                      key, (int)status);
+            }
+        } else if ([self shouldAttemptAccessibilityMigration] &&
+                   update[(__bridge id)kSecAttrAccessible] != nil) {
+            NSLog(@"[flutter_keychain] accessibility migration succeeded for "
+                  @"key '%@' (trigger: put)",
+                  key);
         }
     } else {
-        // Item does not exist — add it.
-        search[(__bridge id)kSecValueData] = [value dataUsingEncoding:NSUTF8StringEncoding];
-        search[(__bridge id)kSecMatchLimit] = nil;
-        status = SecItemAdd((__bridge CFDictionaryRef)search, NULL);
+        NSMutableDictionary *add = [self identityQueryForKey:key];
+        add[(__bridge id)kSecValueData] = data;
+        if (self.configuredAccessible.length > 0) {
+            CFStringRef accessibleConstant =
+                AccessibleConstantForString(self.configuredAccessible);
+            if (accessibleConstant != NULL) {
+                add[(__bridge id)kSecAttrAccessible] =
+                    (__bridge id)accessibleConstant;
+            }
+        }
+        status = SecItemAdd((__bridge CFDictionaryRef)add, NULL);
         if (status != noErr) {
             NSLog(@"[flutter_keychain] SecItemAdd status = %d", (int)status);
         }
@@ -173,17 +320,16 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
 }
 
 - (nullable NSString *)get:(NSString *)key {
-    NSMutableDictionary *search = [self.baseQuery mutableCopy];
-    search[(__bridge id)kSecAttrAccount] = key;
-    search[(__bridge id)kSecReturnData]  = (__bridge id)kCFBooleanTrue;
+    NSMutableDictionary *search = [self identityQueryForKey:key];
+    search[(__bridge id)kSecReturnData] = (__bridge id)kCFBooleanTrue;
     search[(__bridge id)kSecMatchLimit]  = (__bridge id)kSecMatchLimitOne;
 
     CFDataRef resultData = NULL;
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)search,
                                           (CFTypeRef *)&resultData);
     if (status == noErr && resultData != NULL) {
-        // __bridge_transfer gives ARC ownership, so no manual CFRelease needed.
         NSData *data = (__bridge_transfer NSData *)resultData;
+        [self migrateAccessibilityForKey:key withData:data];
         return [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }
     if (resultData != NULL) {
@@ -193,13 +339,12 @@ static CFStringRef AccessibleConstantForString(NSString *accessible) {
 }
 
 - (void)remove:(NSString *)key {
-    NSMutableDictionary *search = [self.baseQuery mutableCopy];
-    search[(__bridge id)kSecAttrAccount] = key;
+    NSMutableDictionary *search = [self identityQueryForKey:key];
     SecItemDelete((__bridge CFDictionaryRef)search);
 }
 
 - (void)clear {
-    NSMutableDictionary *search = [self.baseQuery mutableCopy];
+    NSMutableDictionary *search = [self.identityQuery mutableCopy];
     SecItemDelete((__bridge CFDictionaryRef)search);
 }
 

--- a/ios/Classes/FlutterKeychainPlugin.m
+++ b/ios/Classes/FlutterKeychainPlugin.m
@@ -31,17 +31,37 @@ static NSString *const CHANNEL_NAME     = @"plugin.appmire.be/flutter_keychain";
 // ---------------------------------------------------------------------------
 
 @interface FlutterKeychainPlugin ()
-/// Base query dictionary rebuilt by -configureWithAccessGroup:label:.
+/// Base query dictionary rebuilt by -configureWithAccessGroup:label:accessible:.
 @property (nonatomic, copy) NSDictionary *baseQuery;
 @end
+
+// Maps Dart [FlutterKeychainAccessible] values to kSecAttrAccessible constants.
+static CFStringRef AccessibleConstantForString(NSString *accessible) {
+    if ([@"whenUnlocked" isEqualToString:accessible]) {
+        return kSecAttrAccessibleWhenUnlocked;
+    }
+    if ([@"afterFirstUnlock" isEqualToString:accessible]) {
+        return kSecAttrAccessibleAfterFirstUnlock;
+    }
+    if ([@"whenPasscodeSetThisDeviceOnly" isEqualToString:accessible]) {
+        return kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
+    }
+    if ([@"whenUnlockedThisDeviceOnly" isEqualToString:accessible]) {
+        return kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
+    }
+    if ([@"afterFirstUnlockThisDeviceOnly" isEqualToString:accessible]) {
+        return kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+    }
+    return NULL;
+}
 
 @implementation FlutterKeychainPlugin
 
 - (instancetype)init {
     self = [super init];
     if (self) {
-        // Default: app-specific access group, no label.
-        [self configureWithAccessGroup:nil label:nil];
+        // Default: app-specific access group, no label, system accessible default.
+        [self configureWithAccessGroup:nil label:nil accessible:nil];
     }
     return self;
 }
@@ -59,7 +79,8 @@ static NSString *const CHANNEL_NAME     = @"plugin.appmire.be/flutter_keychain";
 // ---------------------------------------------------------------------------
 
 - (void)configureWithAccessGroup:(nullable NSString *)accessGroup
-                           label:(nullable NSString *)label {
+                           label:(nullable NSString *)label
+                      accessible:(nullable NSString *)accessible {
     NSMutableDictionary *q = [NSMutableDictionary dictionary];
     q[(__bridge id)kSecClass]       = (__bridge id)kSecClassGenericPassword;
     q[(__bridge id)kSecAttrService] = KEYCHAIN_SERVICE;
@@ -68,6 +89,12 @@ static NSString *const CHANNEL_NAME     = @"plugin.appmire.be/flutter_keychain";
     }
     if (label.length > 0) {
         q[(__bridge id)kSecAttrLabel] = label;
+    }
+    if (accessible.length > 0) {
+        CFStringRef accessibleConstant = AccessibleConstantForString(accessible);
+        if (accessibleConstant != NULL) {
+            q[(__bridge id)kSecAttrAccessible] = (__bridge id)accessibleConstant;
+        }
     }
     self.baseQuery = [q copy];
 }
@@ -84,7 +111,18 @@ static NSString *const CHANNEL_NAME     = @"plugin.appmire.be/flutter_keychain";
             ? args[@"accessGroup"] : nil;
         NSString *label = [args[@"label"] isKindOfClass:[NSString class]]
             ? args[@"label"] : nil;
-        [self configureWithAccessGroup:accessGroup label:label];
+        NSString *accessible = [args[@"accessible"] isKindOfClass:[NSString class]]
+            ? args[@"accessible"] : nil;
+        if (accessible.length > 0 &&
+            AccessibleConstantForString(accessible) == NULL) {
+            result([FlutterError errorWithCode:@"INVALID_ACCESSIBLE"
+                                       message:@"Unknown accessible value"
+                                       details:accessible]);
+            return;
+        }
+        [self configureWithAccessGroup:accessGroup
+                                 label:label
+                            accessible:accessible];
         result(nil);
     } else if ([@"get" isEqualToString:call.method]) {
         result([self get:call.key]);

--- a/lib/flutter_keychain.dart
+++ b/lib/flutter_keychain.dart
@@ -5,6 +5,31 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+/// iOS Keychain accessibility (`kSecAttrAccessible`) for stored items.
+///
+/// Has no effect on Android.
+enum FlutterKeychainAccessible {
+  /// `kSecAttrAccessibleWhenUnlocked`
+  whenUnlocked('whenUnlocked'),
+
+  /// `kSecAttrAccessibleAfterFirstUnlock`
+  afterFirstUnlock('afterFirstUnlock'),
+
+  /// `kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly`
+  whenPasscodeSetThisDeviceOnly('whenPasscodeSetThisDeviceOnly'),
+
+  /// `kSecAttrAccessibleWhenUnlockedThisDeviceOnly`
+  whenUnlockedThisDeviceOnly('whenUnlockedThisDeviceOnly'),
+
+  /// `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`
+  afterFirstUnlockThisDeviceOnly('afterFirstUnlockThisDeviceOnly');
+
+  const FlutterKeychainAccessible(this.value);
+
+  /// Stable string sent over the method channel to iOS.
+  final String value;
+}
+
 /// Provides static helpers for storing and retrieving secure key-value pairs.
 class FlutterKeychain {
   static const MethodChannel _channel =
@@ -26,15 +51,20 @@ class FlutterKeychain {
   /// [label] sets `kSecAttrLabel`, which controls how the item appears in the
   /// iOS Passwords app.
   ///
+  /// [accessible] sets `kSecAttrAccessible`, controlling when Keychain items
+  /// can be read (for example only while the device is unlocked).
+  ///
   /// Call this before the first [get], [put], [remove], or [clear] when
   /// non-default values are required.
   static Future<void> configure({
     String? accessGroup,
     String? label,
+    FlutterKeychainAccessible? accessible,
   }) async =>
       _channel.invokeMethod('configure', {
         'accessGroup': accessGroup,
         'label': label,
+        'accessible': accessible?.value,
       });
 
   /// Stores [value] for [key].

--- a/lib/flutter_keychain.dart
+++ b/lib/flutter_keychain.dart
@@ -30,6 +30,26 @@ enum FlutterKeychainAccessible {
   final String value;
 }
 
+/// How iOS should handle existing Keychain items whose `kSecAttrAccessible`
+/// differs from the value passed to [FlutterKeychain.configure].
+///
+/// Has no effect on Android.
+enum FlutterKeychainAccessibilityMigration {
+  /// Do not change existing items. Reads remain compatible with older entries;
+  /// only newly added items use the configured [FlutterKeychainAccessible].
+  none('none'),
+
+  /// After a successful read or update, attempt to migrate the item to the
+  /// configured [FlutterKeychainAccessible]. Migration failures are logged and
+  /// do not affect the operation result.
+  automatic('automatic');
+
+  const FlutterKeychainAccessibilityMigration(this.value);
+
+  /// Stable string sent over the method channel to iOS.
+  final String value;
+}
+
 /// Provides static helpers for storing and retrieving secure key-value pairs.
 class FlutterKeychain {
   static const MethodChannel _channel =
@@ -51,8 +71,14 @@ class FlutterKeychain {
   /// [label] sets `kSecAttrLabel`, which controls how the item appears in the
   /// iOS Passwords app.
   ///
-  /// [accessible] sets `kSecAttrAccessible`, controlling when Keychain items
-  /// can be read (for example only while the device is unlocked).
+  /// [accessible] sets `kSecAttrAccessible` for **new** items and for migration
+  /// when [accessibilityMigration] is [FlutterKeychainAccessibilityMigration.automatic].
+  /// Reads and deletes do not filter by this attribute, so older entries remain
+  /// readable after you change the configured value.
+  ///
+  /// [accessibilityMigration] controls whether existing items are lazily migrated
+  /// to [accessible] after a successful read or update. Defaults to
+  /// [FlutterKeychainAccessibilityMigration.none].
   ///
   /// Call this before the first [get], [put], [remove], or [clear] when
   /// non-default values are required.
@@ -60,11 +86,14 @@ class FlutterKeychain {
     String? accessGroup,
     String? label,
     FlutterKeychainAccessible? accessible,
+    FlutterKeychainAccessibilityMigration accessibilityMigration =
+        FlutterKeychainAccessibilityMigration.none,
   }) async =>
       _channel.invokeMethod('configure', {
         'accessGroup': accessGroup,
         'label': label,
         'accessible': accessible?.value,
+        'accessibilityMigration': accessibilityMigration.value,
       });
 
   /// Stores [value] for [key].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keychain
 description: Flutter secure storage via Keychain (iOS) and Keystore (Android). Supports optional iOS access groups, item labels, and kSecAttrAccessible.
-version: 3.1.0
+version: 3.1.1
 homepage: https://github.com/jeroentrappers/flutter_keychain
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_keychain
-description: Flutter secure storage via Keychain (iOS) and Keystore (Android). Supports optional iOS access groups and item labels.
-version: 3.0.1
+description: Flutter secure storage via Keychain (iOS) and Keystore (Android). Supports optional iOS access groups, item labels, and kSecAttrAccessible.
+version: 3.1.0
 homepage: https://github.com/jeroentrappers/flutter_keychain
 
 environment:

--- a/test/flutter_keychain_test.dart
+++ b/test/flutter_keychain_test.dart
@@ -272,10 +272,14 @@ void main() {
       });
 
       await FlutterKeychain.configure(
-          accessGroup: 'group.com.example', label: 'My App');
+        accessGroup: 'group.com.example',
+        label: 'My App',
+        accessible: FlutterKeychainAccessible.afterFirstUnlock,
+      );
       expect(captured?.method, 'configure');
       expect(captured?.arguments['accessGroup'], 'group.com.example');
       expect(captured?.arguments['label'], 'My App');
+      expect(captured?.arguments['accessible'], 'afterFirstUnlock');
     });
 
     test('sends null values when called without arguments', () async {
@@ -290,6 +294,7 @@ void main() {
       expect(captured?.method, 'configure');
       expect(captured?.arguments['accessGroup'], isNull);
       expect(captured?.arguments['label'], isNull);
+      expect(captured?.arguments['accessible'], isNull);
     });
 
     test('completes without throwing', () async {
@@ -320,6 +325,32 @@ void main() {
       await FlutterKeychain.configure(label: 'My Credentials');
       expect(captured?.arguments['accessGroup'], isNull);
       expect(captured?.arguments['label'], 'My Credentials');
+      expect(captured?.arguments['accessible'], isNull);
+    });
+
+    test('configure with only accessible sends stable string token', () async {
+      MethodCall? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        captured = call;
+        return null;
+      });
+
+      await FlutterKeychain.configure(
+        accessible: FlutterKeychainAccessible.whenUnlockedThisDeviceOnly,
+      );
+      expect(captured?.arguments['accessGroup'], isNull);
+      expect(captured?.arguments['label'], isNull);
+      expect(
+        captured?.arguments['accessible'],
+        'whenUnlockedThisDeviceOnly',
+      );
+    });
+
+    test('each FlutterKeychainAccessible value maps to a unique token', () {
+      final values =
+          FlutterKeychainAccessible.values.map((e) => e.value).toList();
+      expect(values.toSet().length, values.length);
     });
   });
 

--- a/test/flutter_keychain_test.dart
+++ b/test/flutter_keychain_test.dart
@@ -275,11 +275,14 @@ void main() {
         accessGroup: 'group.com.example',
         label: 'My App',
         accessible: FlutterKeychainAccessible.afterFirstUnlock,
+        accessibilityMigration:
+            FlutterKeychainAccessibilityMigration.automatic,
       );
       expect(captured?.method, 'configure');
       expect(captured?.arguments['accessGroup'], 'group.com.example');
       expect(captured?.arguments['label'], 'My App');
       expect(captured?.arguments['accessible'], 'afterFirstUnlock');
+      expect(captured?.arguments['accessibilityMigration'], 'automatic');
     });
 
     test('sends null values when called without arguments', () async {
@@ -295,6 +298,7 @@ void main() {
       expect(captured?.arguments['accessGroup'], isNull);
       expect(captured?.arguments['label'], isNull);
       expect(captured?.arguments['accessible'], isNull);
+      expect(captured?.arguments['accessibilityMigration'], 'none');
     });
 
     test('completes without throwing', () async {
@@ -350,6 +354,29 @@ void main() {
     test('each FlutterKeychainAccessible value maps to a unique token', () {
       final values =
           FlutterKeychainAccessible.values.map((e) => e.value).toList();
+      expect(values.toSet().length, values.length);
+    });
+
+    test('configure with automatic migration sends migration token', () async {
+      MethodCall? captured;
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (call) async {
+        captured = call;
+        return null;
+      });
+
+      await FlutterKeychain.configure(
+        accessible: FlutterKeychainAccessible.afterFirstUnlock,
+        accessibilityMigration:
+            FlutterKeychainAccessibilityMigration.automatic,
+      );
+      expect(captured?.arguments['accessibilityMigration'], 'automatic');
+    });
+
+    test('each FlutterKeychainAccessibilityMigration value is unique', () {
+      final values = FlutterKeychainAccessibilityMigration.values
+          .map((e) => e.value)
+          .toList();
       expect(values.toSet().length, values.length);
     });
   });


### PR DESCRIPTION
## Summary

- Add `FlutterKeychainAccessible` and an optional `accessible` parameter on `FlutterKeychain.configure` to set `kSecAttrAccessible` for new iOS Keychain items.
- Fix legacy read compatibility: `get` / `remove` / `clear` no longer filter by `accessible`, so items stored with the system default (`whenUnlocked`) remain readable after reconfiguring to e.g. `afterFirstUnlock`.
- Add `FlutterKeychainAccessibilityMigration` (`none` | `automatic`) for optional lazy migration of existing items via `SecItemUpdate` on successful `get` or `put` update, with structured migration logging.
- Bump package version to **3.1.1**. Android `configure` remains a no-op for iOS-only settings.

## Commits included

1. `feat: add iOS kSecAttrAccessible support via configure`
2. `fix: iOS accessible migration and legacy keychain read compatibility`
3. `chore: bump version to 3.1.1`

## Usage

```dart
// New items use afterFirstUnlock; existing items stay readable (default).
await FlutterKeychain.configure(
  accessible: FlutterKeychainAccessible.afterFirstUnlock,
);

// Opt in to lazy migration of legacy items.
await FlutterKeychain.configure(
  accessible: FlutterKeychainAccessible.afterFirstUnlock,
  accessibilityMigration: FlutterKeychainAccessibilityMigration.automatic,
);